### PR TITLE
Fix installation failure on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic
 sudo: false
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ stages:
 - lint
 - test
 
-env:
-  global:
-    - VIRTUALENV_DOWNLOAD=1
-
 jobs:
   include:
   - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ jobs:
     env: TOXENV=py37
 
 install: pip install tox-travis
-script: tox
+script: tox -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   include:
   - stage: lint
     python: "3.7"
-    env: TOXENV=lint
+    env: TOXENV=lint VIRTUALENV_VERBOSE=1
 
   - if: type = pull_request
     stage: test
@@ -28,4 +28,4 @@ jobs:
     env: TOXENV=py37
 
 install: pip install tox-travis
-script: tox -vv
+script: tox -vvv

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
   include:
   - stage: lint
     python: "3.7"
-    env: TOXENV=lint VIRTUALENV_VERBOSE=1
+    env: TOXENV=lint
 
   - if: type = pull_request
     stage: test
@@ -28,4 +28,4 @@ jobs:
     env: TOXENV=py37
 
 install: pip install tox-travis
-script: tox -vv
+script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ jobs:
     env: TOXENV=py37
 
 install: pip install tox-travis
-script: tox -vvv
+script: tox -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ stages:
 - lint
 - test
 
+env:
+  global:
+    - VIRTUALENV_DOWNLOAD=1
+
 jobs:
   include:
   - stage: lint


### PR DESCRIPTION
Travis builds started failing because it was using a version of `pip` that didn't work with non-setuptools packages. Running on Ubuntu 18.04 instead of 16.04 seems to fix it.