### PR TITLE
Fix isort 5 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 test = [
     "black; python_version >= '3.6'",
     "flake8",
-    "isort ~= 5.0.0",
+    "isort ~= 5.0.0; python_version >= '3.6'",
     "pytest",
     "pytest-cov",
     "pytest-mock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 test = [
     "black; python_version >= '3.6'",
     "flake8",
-    "isort",
+    "isort ~= 5.0.0",
     "pytest",
     "pytest-cov",
     "pytest-mock",
@@ -48,10 +48,5 @@ test = [
 rofi-tmuxp = "rofi_tmuxp:main"
 
 [tool.isort]
-line_width = 88
-multi_line_output = 3
+profile="black"
 lines_after_imports = 2
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-known_first_party = ["test"]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ deps =
 commands =
     flake8 {[common]sources}
     black --check --verbose --diff {[common]sources}
-    isort --recursive --check-only --diff {[common]sources}
+    isort --check-only --diff {[common]sources}
     rstcheck -r .
 
 [flake8]


### PR DESCRIPTION
isort introduced some breaking changes in version 5.0.0. Update
command line options accordingly and take advantage of some newer isort
features.