### PR TITLE
Handle recent tmuxp API changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Heinrich Kruger", email = "heindsight@kruger.dev"}
 ]
 readme = "README.rst"
-version = "0.3.0.dev0"
+version = "0.3.0"
 dynamic = ["description"]
 keywords = ["rofi", "tmux", "tmuxp"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
     {name = "Heinrich Kruger", email = "heindsight@kruger.dev"}
 ]
 readme = "README.rst"
-version = "0.2.0"
+version = "0.3.0.dev0"
 dynamic = ["description"]
 keywords = ["rofi", "tmux", "tmuxp"]
 classifiers = [

--- a/rofi_tmuxp.py
+++ b/rofi_tmuxp.py
@@ -8,6 +8,13 @@ import tmuxp
 from kaptan import Kaptan
 
 
+try:
+    # get_config_dir moved to `tmuxp.cli.utils` in tmuxp 1.11.0
+    from tmuxp.cli.utils import get_config_dir
+except ImportError:  # pragma: no cover
+    from tmuxp.cli import get_config_dir
+
+
 logger = logging.getLogger("rofi_tmuxp")
 
 
@@ -45,7 +52,7 @@ def get_sessions():
 
     Returns a dictionary mapping session name to config file paths.
     """
-    config_dir = Path(tmuxp.cli.get_config_dir())
+    config_dir = Path(get_config_dir())
     sessions = {}
 
     for filename in tmuxp.config.in_dir(str(config_dir)):
@@ -68,7 +75,7 @@ def _load_config(cfg_path):
     Raises `ValidationError` if the config does not define a session name"""
     config = Kaptan()
     config.import_config(str(cfg_path))
-    config = tmuxp.cli.config.expand(config.configuration_data)
+    config = tmuxp.config.expand(config.configuration_data)
 
     if "session_name" not in config:
         raise ValidationError("No session name configured")

--- a/test/test_rofi_tmuxp.py
+++ b/test/test_rofi_tmuxp.py
@@ -40,7 +40,7 @@ def config_file(write_config):
 
 @pytest.fixture(autouse=True)
 def mock_get_config_dir(mocker, config_dir):
-    m = mocker.patch("rofi_tmuxp.tmuxp.cli.get_config_dir")
+    m = mocker.patch("rofi_tmuxp.get_config_dir")
     m.return_value = str(config_dir)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 isolated_build = True
 envlist =
     lint
-    {py37, py38, py39}-tmuxp{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9}-kaptan{0.5.10, 0.5.11, 0.5.12}
-    {py310,py311}-tmuxp{1.5, 1.6, 1.7, 1.8, 1.9}-kaptan0.5.12
+    {py37, py38, py39}-tmuxp{1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11}-kaptan{0.5.10, 0.5.11, 0.5.12}
+    {py310,py311}-tmuxp{1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11}-kaptan0.5.12
 
 [common]
 sources = rofi_tmuxp.py test
@@ -28,6 +28,8 @@ deps =
     tmuxp1.7: tmuxp~=1.7.0
     tmuxp1.8: tmuxp~=1.8.0
     tmuxp1.9: tmuxp~=1.9.0
+    tmuxp1.10: tmuxp~=1.10.0
+    tmuxp1.11: tmuxp~=1.11.0
     kaptan0.5.10: kaptan==0.5.10
     kaptan0.5.11: kaptan==0.5.11
     kaptan0.5.12: kaptan==0.5.12


### PR DESCRIPTION
In tmuxp 1.11, the `cli` module was converted to a package and the `cli.get_config_dir()` function moved to `cli.utils.get_config_dir()`.