### PR TITLE
Drop kaptan dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = "~=3.7"
 dependencies = [
-    "kaptan ~= 0.5.10",
+    "pyyaml",
     "tmuxp ~= 1.1"
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 isolated_build = True
 envlist =
     lint
-    {py37, py38, py39}-tmuxp{1.1, 1.4}-kaptan{0.5.10, 0.5.12}
-    {py37, py38, py39, py310, py311}-tmuxp{1.5, 1.15}-kaptan0.5.12
+    {py37, py38, py39}-tmuxp{1.1, 1.4}
+    {py37, py38, py39, py310, py311}-tmuxp{1.5, 1.16}
 
 [common]
 sources = rofi_tmuxp.py test
@@ -23,9 +23,7 @@ deps =
     tmuxp1.4: tmuxp~=1.5.0
     tmuxp1.5: tmuxp~=1.5.0
     tmuxp{1.4,1.5}: libtmux<0.15.0
-    tmuxp1.15: tmuxp~=1.15.0
-    kaptan0.5.10: kaptan==0.5.10
-    kaptan0.5.12: kaptan==0.5.12
+    tmuxp1.16: tmuxp~=1.16.0
     pytest
     pytest-cov
     pytest-mock


### PR DESCRIPTION
Tmuxp stopped using `kaptan` to load config in version `1.16.0`. Rather than continuing to require a seemingly unmaintained library, rofi-tmuxp will now use the tmuxp `ConfigReader` to load session configs. For older tmuxp versions, where this is not available, we fall back to using pyyaml instead (we don't need to bother trying to distinguish between json and yaml configs because yaml is a superset of json).