### PR TITLE
Improve coverage measurement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black",
-    "coverage-conditional-plugin",
     "flake8",
     "flake8-pytest-style",
     "isort ~= 5.0.0",

--- a/rofi_tmuxp/tmuxp_client.py
+++ b/rofi_tmuxp/tmuxp_client.py
@@ -1,7 +1,7 @@
 """Tmuxp compatibility layer"""
 try:
     from tmuxp.config_reader import ConfigReader
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: has_tmuxp_1_16
     # In tmuxp < 1.16, 3d party library `Kaptan` was used to read config files.
     # `Kaptan` is just a wrapper around `yaml.safe_load` and `json.load`. Since Yaml is
     # a superset of JSON, we just use `yaml.safe_load` and wrap it in a class with
@@ -21,24 +21,24 @@ except ImportError:  # pragma: no cover
 
 try:
     from tmuxp.workspace.loader import expand as expand_config
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: has_tmuxp_1_18
     # In tmuxp < 1.18, `expand` was in `tmuxp.config`
     from tmuxp.config import expand as expand_config
 
 try:
     from tmuxp.workspace.finders import get_workspace_dir
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: has_tmuxp_1_18
     # In tmuxp < 1.18, `get_workspace_dir` was called `get_config_dir`.
     # In tmuxp >= 1.11, < 1.18 get_config_dir was in `tmuxp.cli.utils`.
     # In tmuxp < 1.11, get_config_dir was in tmuxp.cli.
     try:
         from tmuxp.cli.utils import get_config_dir as get_workspace_dir
-    except ImportError:  # pragma: no cover
+    except ImportError:  # pragma: has_tmuxp_1_11
         from tmuxp.cli import get_config_dir as get_workspace_dir
 
 try:
     from tmuxp.workspace.finders import in_dir as configs_in_dir
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: has_tmuxp_1_18
     # In tmuxp < 1.18, `in_dir` was in `tmuxp.config`
     from tmuxp.config import in_dir as configs_in_dir
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ deps =
     pytest-cov
     pytest-mock
     pytest-randomly
+    coverage-conditional-plugin
 
 [testenv:lint]
 extras = dev
@@ -59,3 +60,14 @@ addopts =
     --cov-fail-under=100
     --cov-branch
     --no-cov-on-fail
+
+
+[coverage:run]
+plugins =
+  coverage_conditional_plugin
+
+[coverage:coverage_conditional_plugin]
+rules =
+    "package_version('tmuxp') >= (1, 11, 0)": has_tmuxp_1_11
+    "package_version('tmuxp') >= (1, 16, 0)": has_tmuxp_1_16
+    "package_version('tmuxp') >= (1, 18, 0)": has_tmuxp_1_18


### PR DESCRIPTION
Use the [coverage-conditional-plugin](https://github.com/wemake-services/coverage-conditional-plugin) to conditionally exclude code from coverage measurement based on the tmuxp version.